### PR TITLE
Clarify GenAI reference entries and link to guide pages

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -15,6 +15,10 @@ To use the plugin's features, you need an account and API credentials from one o
 **On self-managed instances**, you install the plugin by moving the `neo4j-genai.jar` file from `<NEO4J_HOME>/products` to `<NEO4J_HOME>/plugins`, or, if you are using Docker, by starting the Docker container with the extra parameter `--env NEO4J_PLUGINS='["genai"]'`.
 For more information, see link:{neo4j-docs-base-uri}/operations-manual/current/configuration/plugins/[Operations Manual -> Configure plugins].
 
+[IMPORTANT]
+Most GenAI features are available only in Cypher 25.
+If your database's default language is Cypher 5, prepend the query with `CYPHER 25` to override the default for that query (see link:https://neo4j.com/docs/cypher-manual/current/queries/select-version/[Cypher -> Select Cypher version]).
+
 
 [[setup]]
 == Environment setup

--- a/modules/ROOT/pages/reference/functions-procedures.adoc
+++ b/modules/ROOT/pages/reference/functions-procedures.adoc
@@ -20,21 +20,7 @@ If your database’s default language is Cypher 5, prepend the query with CYPHER
 2+| *Returns*                            | `STRING` | Generated text based on the provided prompt.
 |===
 
-.Example
-[source,cypher]
-----
-CYPHER 25 // Keep this prefix if the database default is Cypher 5.
-WITH 'YOUR_OPENAI_API_KEY' AS openaiToken  // replace with a real token
-WITH {
-  token: openaiToken,
-  model: 'gpt-5-nano'
-} AS conf
-RETURN ai.text.completion(
-  'Write a one-sentence tagline for a graph database.',
-  'openai',
-  conf
-) AS text;
-----
+For usage examples, see xref:generate-text.adoc#generate-once[Generate text from prompt].
 
 
 [[ai-text-completion-providers]]
@@ -50,14 +36,7 @@ RETURN ai.text.completion(
 |                         `defaultConfig`      | `MAP`    | Default configuration option values.
 |===
 
-.Example
-[source,cypher]
-----
-CYPHER 25 // Keep this prefix if the database default is Cypher 5.
-CALL ai.text.completion.providers()
-YIELD name, requiredConfigType, optionalConfigType, defaultConfig
-RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
-----
+For provider details and examples, see xref:generate-text.adoc#providers[Generate text -> Providers].
 
 
 [[ai-text-completion-with-structure]]
@@ -74,33 +53,7 @@ RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
 2+| *Returns*                            | `MAP`    | A structured map conforming to the provided schema.
 |===
 
-.Example
-[source,cypher]
-----
-CYPHER 25 // Keep this prefix if the database default is Cypher 5.
-WITH
-  'YOUR_OPENAI_API_KEY' AS openaiToken,  // replace with a real token
-  {
-    type: 'object',
-    properties: {
-      answer: {type: 'string'}
-    },
-    required: ['answer'],
-    additionalProperties: false
-  } AS schema
-WITH
-  schema,
-  {
-    token: openaiToken,
-    model: 'gpt-5-nano'
-  } AS conf
-RETURN ai.text.structuredCompletion(
-  'Answer in one short sentence: what is Cypher?',
-  schema,
-  'openai',
-  conf
-) AS result;
-----
+For usage examples, see xref:generate-structured-output.adoc[Generate structured output].
 
 
 [[ai-text-completion-with-structure-providers]]
@@ -116,14 +69,7 @@ RETURN ai.text.structuredCompletion(
 |                         `defaultConfig`      | `MAP`    | Default configuration option values.
 |===
 
-.Example
-[source,cypher]
-----
-CYPHER 25 // Keep this prefix if the database default is Cypher 5.
-CALL ai.text.structuredCompletion.providers()
-YIELD name, requiredConfigType, optionalConfigType, defaultConfig
-RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
-----
+For provider details and examples, see xref:generate-structured-output.adoc#providers[Generate structured output -> Providers].
 
 
 [[ai-text-chat]]
@@ -141,22 +87,7 @@ RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
 
 |===
 
-.Example
-[source,cypher]
-----
-CYPHER 25 // Keep this prefix if the database default is Cypher 5.
-WITH 'YOUR_OPENAI_API_KEY' AS openaiToken  // replace with a real token
-WITH {
-  token: openaiToken,
-  model: 'gpt-5-nano'
-} AS conf
-RETURN ai.text.chat(
-  'Say hello in five words or fewer.',
-  null,      // null starts a new chat
-  'openai',
-  conf
-) AS chat;
-----
+For usage examples, see xref:generate-text.adoc#chat-with-context[Chat with context].
 
 
 [[ai-text-chat-providers]]
@@ -172,14 +103,7 @@ RETURN ai.text.chat(
 |                         `defaultConfig`      | `MAP`    | Default configuration option values.
 |===
 
-.Example
-[source,cypher]
-----
-CYPHER 25 // Keep this prefix if the database default is Cypher 5.
-CALL ai.text.chat.providers()
-YIELD name, requiredConfigType, optionalConfigType, defaultConfig
-RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
-----
+For provider details and examples, see xref:generate-text.adoc#providers[Generate text -> Providers].
 
 
 [[ai-text-embed]]
@@ -196,21 +120,7 @@ RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
 2+| *Returns* | `VECTOR` | The generated vector embedding for the resource.
 |===
 
-.Example
-[source,cypher]
-----
-CYPHER 25 // Keep this prefix if the database default is Cypher 5.
-WITH 'YOUR_OPENAI_API_KEY' AS openaiToken  // replace with a real token
-WITH {
-  token: openaiToken,
-  model: 'text-embedding-3-small'
-} AS conf
-RETURN ai.text.embed(
-  'Neo4j works well for connected data.',
-  'openai',
-  conf
-) AS embedding;
-----
+For usage examples, see xref:embeddings.adoc#single-embedding[Generate and store a single embedding].
 
 
 [[ai-text-embed-batch]]
@@ -230,23 +140,7 @@ RETURN ai.text.embed(
 | `vector` | `VECTOR` | The generated vector embedding for the resource.
 |===
 
-.Example
-[source,cypher]
-----
-CYPHER 25 // Keep this prefix if the database default is Cypher 5.
-WITH
-  'YOUR_OPENAI_API_KEY' AS openaiToken,  // replace with a real token
-  ['graph database', 'vector search'] AS texts
-WITH
-  texts,
-  {
-    token: openaiToken,
-    model: 'text-embedding-3-small'
-  } AS conf
-CALL ai.text.embedBatch(texts, 'openai', conf)
-YIELD index, resource, vector
-RETURN index, resource, vector;
-----
+For usage examples, see xref:embeddings.adoc#multiple-embeddings[Generate and store a batch of embeddings].
 
 
 [[ai-text-embed-providers]]
@@ -263,14 +157,7 @@ RETURN index, resource, vector;
 | `defaultConfig` | `MAP` | The default values for the GenAI provider.
 |===
 
-.Example
-[source,cypher]
-----
-CYPHER 25 // Keep this prefix if the database default is Cypher 5.
-CALL ai.text.embed.providers()
-YIELD name, requiredConfigType, optionalConfigType, defaultConfig
-RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
-----
+For provider details and examples, see xref:embeddings.adoc#providers[Embeddings -> Providers].
 
 
 [[genai-vector-encode]]
@@ -291,21 +178,7 @@ Use xref:reference/functions-procedures.adoc#ai-text-embed[`ai.text.embed()`] in
 2+| *Returns* | `ANY` | The generated vector embedding for the resource.
 |===
 
-.Example
-[source,cypher]
-----
-// Legacy callable, deprecated in Cypher 25. Prefer ai.text.embed() for new examples.
-WITH 'YOUR_OPENAI_API_KEY' AS openaiToken  // replace with a real token
-WITH {
-  token: openaiToken,
-  model: 'text-embedding-ada-002'
-} AS conf
-RETURN genai.vector.encode(
-  'Neo4j works well for connected data.',
-  'OpenAI',
-  conf
-) AS embedding;
-----
+For current usage examples, see xref:embeddings.adoc#single-embedding[Generate and store a single embedding].
 
 
 [[genai-vector-encode-batch]]
@@ -329,23 +202,7 @@ Use xref:reference/functions-procedures.adoc#ai-text-embed-batch[`ai.text.embedB
 | `vector` | `ANY` | The generated vector embedding for the resource.
 |===
 
-.Example
-[source,cypher]
-----
-// Legacy callable, deprecated in Cypher 25. Prefer ai.text.embedBatch() for new examples.
-WITH
-  'YOUR_OPENAI_API_KEY' AS openaiToken,  // replace with a real token
-  ['graph database', 'vector search'] AS texts
-WITH
-  texts,
-  {
-    token: openaiToken,
-    model: 'text-embedding-ada-002'
-  } AS conf
-CALL genai.vector.encodeBatch(texts, 'OpenAI', conf)
-YIELD index, resource, vector
-RETURN index, resource, vector;
-----
+For current usage examples, see xref:embeddings.adoc#multiple-embeddings[Generate and store a batch of embeddings].
 
 
 [[genai-vector-list-encoding-providers]]
@@ -366,11 +223,4 @@ Use xref:reference/functions-procedures.adoc#ai-text-embed-providers[`ai.text.em
 | `defaultConfig` | `MAP` | The default values for the GenAI provider.
 |===
 
-.Example
-[source,cypher]
-----
-// Legacy callable, deprecated in Cypher 25. Prefer ai.text.embed.providers().
-CALL genai.vector.listEncodingProviders()
-YIELD name, requiredConfigType, optionalConfigType, defaultConfig
-RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
-----
+For current provider details and examples, see xref:embeddings.adoc#providers[Embeddings -> Providers].

--- a/modules/ROOT/pages/reference/functions-procedures.adoc
+++ b/modules/ROOT/pages/reference/functions-procedures.adoc
@@ -362,7 +362,7 @@ Use xref:reference/functions-procedures.adoc#ai-text-embed-providers[`ai.text.em
 .5+| *Return arguments* | *Name* | *Type* | *Description*
 | `name` | `STRING` | The name of the GenAI provider.
 | `requiredConfigType` | `STRING` | The signature of the required config map.
-| `optionalConfigType` | `STRING` | "The signature of the optional config map.
+| `optionalConfigType` | `STRING` | The signature of the optional config map.
 | `defaultConfig` | `MAP` | The default values for the GenAI provider.
 |===
 

--- a/modules/ROOT/pages/reference/functions-procedures.adoc
+++ b/modules/ROOT/pages/reference/functions-procedures.adoc
@@ -1,5 +1,17 @@
 = Functions and procedures
 
+[NOTE]
+====
+Functions are used in expressions such as `RETURN`, `WITH`, and `SET`.
+Procedures are invoked with `CALL ... YIELD`.
+For more information, see link:https://neo4j.com/docs/cypher-manual/current/functions/[Cypher Manual -> Functions] and link:https://neo4j.com/docs/cypher-manual/current/clauses/call/[Cypher Manual -> CALL procedure].
+====
+
+[NOTE]
+====
+Entries marked `Cypher 25` are only available when the query runs with Cypher 25.
+For more information, see link:https://neo4j.com/docs/cypher-manual/current/queries/select-version/[Cypher Manual -> Select Cypher version].
+====
 
 [[ai-text-completion]]
 [role=label--function label--new-2025.11 label--Cypher-25]
@@ -14,6 +26,12 @@
 2+| *Returns*                            | `STRING` | Generated text based on the provided prompt.
 |===
 
+.Example
+[source,cypher]
+----
+RETURN ai.text.completion('Write a one-sentence movie summary.', 'openai', {token: $openaiToken, model: 'gpt-4.1-mini'}) AS completion
+----
+
 
 [[ai-text-completion-providers]]
 [role=label--procedure label--new-2025.11 label--Cypher-25]
@@ -27,6 +45,14 @@
 |                         `optionalConfigType` | `STRING` | The signature of the optional configuration options.
 |                         `defaultConfig`      | `MAP`    | Default configuration option values.
 |===
+
+.Example
+[source,cypher]
+----
+CALL ai.text.completion.providers()
+YIELD name, requiredConfigType
+RETURN name, requiredConfigType
+----
 
 
 [[ai-text-completion-with-structure]]
@@ -43,6 +69,17 @@
 2+| *Returns*                            | `MAP`    | A structured map conforming to the provided schema.
 |===
 
+.Example
+[source,cypher]
+----
+RETURN ai.text.structuredCompletion(
+  'Extract the name and role from "Alice is an engineer".',
+  {type: 'object', properties: {name: {type: 'string'}, role: {type: 'string'}}},
+  'openai',
+  {token: $openaiToken, model: 'gpt-4.1-mini'}
+) AS result
+----
+
 
 [[ai-text-completion-with-structure-providers]]
 [role=label--procedure label--new-2026.02 label--Cypher-25]
@@ -56,6 +93,14 @@
 |                         `optionalConfigType` | `STRING` | The signature of the optional configuration options.
 |                         `defaultConfig`      | `MAP`    | Default configuration option values.
 |===
+
+.Example
+[source,cypher]
+----
+CALL ai.text.structuredCompletion.providers()
+YIELD name, requiredConfigType
+RETURN name, requiredConfigType
+----
 
 
 [[ai-text-chat]]
@@ -73,6 +118,12 @@
 
 |===
 
+.Example
+[source,cypher]
+----
+RETURN ai.text.chat('Hello', null, 'openai', {token: $openaiToken, model: 'gpt-4.1-mini'}) AS chat
+----
+
 
 [[ai-text-chat-providers]]
 [role=label--procedure label--new-2025.12 label--Cypher-25]
@@ -86,6 +137,14 @@
 |                         `optionalConfigType` | `STRING` | The signature of the optional configuration options.
 |                         `defaultConfig`      | `MAP`    | Default configuration option values.
 |===
+
+.Example
+[source,cypher]
+----
+CALL ai.text.chat.providers()
+YIELD name, requiredConfigType
+RETURN name, requiredConfigType
+----
 
 
 [[ai-text-embed]]
@@ -101,6 +160,12 @@
 | `configuration` | `MAP` | The provider specific settings.
 2+| *Returns* | `VECTOR` | The generated vector embedding for the resource.
 |===
+
+.Example
+[source,cypher]
+----
+RETURN ai.text.embed('The Matrix is a science fiction film.', 'openai', {token: $openaiToken, model: 'text-embedding-3-small'}) AS embedding
+----
 
 
 [[ai-text-embed-batch]]
@@ -120,6 +185,14 @@
 | `vector` | `VECTOR` | The generated vector embedding for the resource.
 |===
 
+.Example
+[source,cypher]
+----
+CALL ai.text.embedBatch(['The Matrix', 'The Matrix Reloaded'], 'openai', {token: $openaiToken, model: 'text-embedding-3-small'})
+YIELD index, resource, vector
+RETURN index, resource, vector
+----
+
 
 [[ai-text-embed-providers]]
 [role=label--procedure label--new-2025.11 label--Cypher-25]
@@ -135,6 +208,14 @@
 | `defaultConfig` | `MAP` | The default values for the GenAI provider.
 |===
 
+.Example
+[source,cypher]
+----
+CALL ai.text.embed.providers()
+YIELD name, requiredConfigType
+RETURN name, requiredConfigType
+----
+
 
 [[genai-vector-encode]]
 [role=label--function label--deprecated-Cypher-25]
@@ -149,6 +230,12 @@
 | `configuration` | `MAP` | The provider specific settings.
 2+| *Returns* | `ANY` | The generated vector embedding for the resource.
 |===
+
+.Example
+[source,cypher]
+----
+RETURN genai.vector.encode('The Matrix is a science fiction film.', 'OpenAI', {token: $openaiToken, model: 'text-embedding-3-small'}) AS embedding
+----
 
 
 [[genai-vector-encode-batch]]
@@ -168,6 +255,14 @@
 | `vector` | `ANY` | The generated vector embedding for the resource.
 |===
 
+.Example
+[source,cypher]
+----
+CALL genai.vector.encodeBatch(['The Matrix', 'The Matrix Reloaded'], 'OpenAI', {token: $openaiToken, model: 'text-embedding-3-small'})
+YIELD index, resource, vector
+RETURN index, resource, vector
+----
+
 
 [[genai-vector-list-encoding-providers]]
 [role=label--procedure label--deprecated-Cypher-25]
@@ -182,3 +277,11 @@
 | `optionalConfigType` | `STRING` | "The signature of the optional config map.
 | `defaultConfig` | `MAP` | The default values for the GenAI provider.
 |===
+
+.Example
+[source,cypher]
+----
+CALL genai.vector.listEncodingProviders()
+YIELD name, requiredConfigType
+RETURN name, requiredConfigType
+----

--- a/modules/ROOT/pages/reference/functions-procedures.adoc
+++ b/modules/ROOT/pages/reference/functions-procedures.adoc
@@ -1,11 +1,12 @@
 = Functions and procedures
 
-Functions and procedures are different Cypher features: functions are used inside expressions and evaluate to a value, while procedures are invoked with CALL. 
-For details, see the Neo4j documentation on Functions and CALL procedure.
-For more information, see link:https://neo4j.com/docs/cypher-manual/current/functions/[Cypher Manual -> Functions] and link:https://neo4j.com/docs/cypher-manual/current/clauses/call/[Cypher Manual -> CALL procedure].
+[NOTE]
+Functions and procedures are different Cypher features: _functions_ are used inside expressions and evaluate to a value, whereas _procedures_ are invoked with `CALL`.
+For more information, see link:https://neo4j.com/docs/cypher-manual/current/functions/[Cypher -> Functions] and link:https://neo4j.com/docs/cypher-manual/current/clauses/call/[Cypher -> CALL procedure].
 
-Some functions and procedures are available only in Cypher 25. 
-If your database’s default language is Cypher 5, prepend the query with CYPHER 25 to override the default for that query; see link:https://neo4j.com/docs/cypher-manual/current/queries/select-version/[Cypher Manual -> Select Cypher version].
+[IMPORTANT]
+Most GenAI features are available only in Cypher 25.
+If your database's default language is Cypher 5, prepend the query with `CYPHER 25` to override the default for that query (see link:https://neo4j.com/docs/cypher-manual/current/queries/select-version/[Cypher -> Select Cypher version]).
 
 [[ai-text-completion]]
 [role=label--function label--new-2025.11 label--Cypher-25]

--- a/modules/ROOT/pages/reference/functions-procedures.adoc
+++ b/modules/ROOT/pages/reference/functions-procedures.adoc
@@ -1,17 +1,11 @@
 = Functions and procedures
 
-[NOTE]
-====
-Functions are used in expressions such as `RETURN`, `WITH`, and `SET`.
-Procedures are invoked with `CALL ... YIELD`.
+Functions and procedures are different Cypher features: functions are used inside expressions and evaluate to a value, while procedures are invoked with CALL. 
+For details, see the Neo4j documentation on Functions and CALL procedure.
 For more information, see link:https://neo4j.com/docs/cypher-manual/current/functions/[Cypher Manual -> Functions] and link:https://neo4j.com/docs/cypher-manual/current/clauses/call/[Cypher Manual -> CALL procedure].
-====
 
-[NOTE]
-====
-Entries marked `Cypher 25` are only available when the query runs with Cypher 25.
-For more information, see link:https://neo4j.com/docs/cypher-manual/current/queries/select-version/[Cypher Manual -> Select Cypher version].
-====
+Some functions and procedures are available only in Cypher 25. 
+If your database’s default language is Cypher 5, prepend the query with CYPHER 25 to override the default for that query; see link:https://neo4j.com/docs/cypher-manual/current/queries/select-version/[Cypher Manual -> Select Cypher version].
 
 [[ai-text-completion]]
 [role=label--function label--new-2025.11 label--Cypher-25]
@@ -29,7 +23,17 @@ For more information, see link:https://neo4j.com/docs/cypher-manual/current/quer
 .Example
 [source,cypher]
 ----
-RETURN ai.text.completion('Write a one-sentence movie summary.', 'openai', {token: $openaiToken, model: 'gpt-4.1-mini'}) AS completion
+CYPHER 25 // Keep this prefix if the database default is Cypher 5.
+WITH 'YOUR_OPENAI_API_KEY' AS openaiToken  // replace with a real token
+WITH {
+  token: openaiToken,
+  model: 'gpt-5-nano'
+} AS conf
+RETURN ai.text.completion(
+  'Write a one-sentence tagline for a graph database.',
+  'openai',
+  conf
+) AS text;
 ----
 
 
@@ -49,9 +53,10 @@ RETURN ai.text.completion('Write a one-sentence movie summary.', 'openai', {toke
 .Example
 [source,cypher]
 ----
+CYPHER 25 // Keep this prefix if the database default is Cypher 5.
 CALL ai.text.completion.providers()
-YIELD name, requiredConfigType
-RETURN name, requiredConfigType
+YIELD name, requiredConfigType, optionalConfigType, defaultConfig
+RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
 ----
 
 
@@ -72,12 +77,29 @@ RETURN name, requiredConfigType
 .Example
 [source,cypher]
 ----
+CYPHER 25 // Keep this prefix if the database default is Cypher 5.
+WITH
+  'YOUR_OPENAI_API_KEY' AS openaiToken,  // replace with a real token
+  {
+    type: 'object',
+    properties: {
+      answer: {type: 'string'}
+    },
+    required: ['answer'],
+    additionalProperties: false
+  } AS schema
+WITH
+  schema,
+  {
+    token: openaiToken,
+    model: 'gpt-5-nano'
+  } AS conf
 RETURN ai.text.structuredCompletion(
-  'Extract the name and role from "Alice is an engineer".',
-  {type: 'object', properties: {name: {type: 'string'}, role: {type: 'string'}}},
+  'Answer in one short sentence: what is Cypher?',
+  schema,
   'openai',
-  {token: $openaiToken, model: 'gpt-4.1-mini'}
-) AS result
+  conf
+) AS result;
 ----
 
 
@@ -97,9 +119,10 @@ RETURN ai.text.structuredCompletion(
 .Example
 [source,cypher]
 ----
+CYPHER 25 // Keep this prefix if the database default is Cypher 5.
 CALL ai.text.structuredCompletion.providers()
-YIELD name, requiredConfigType
-RETURN name, requiredConfigType
+YIELD name, requiredConfigType, optionalConfigType, defaultConfig
+RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
 ----
 
 
@@ -121,7 +144,18 @@ RETURN name, requiredConfigType
 .Example
 [source,cypher]
 ----
-RETURN ai.text.chat('Hello', null, 'openai', {token: $openaiToken, model: 'gpt-4.1-mini'}) AS chat
+CYPHER 25 // Keep this prefix if the database default is Cypher 5.
+WITH 'YOUR_OPENAI_API_KEY' AS openaiToken  // replace with a real token
+WITH {
+  token: openaiToken,
+  model: 'gpt-5-nano'
+} AS conf
+RETURN ai.text.chat(
+  'Say hello in five words or fewer.',
+  null,      // null starts a new chat
+  'openai',
+  conf
+) AS chat;
 ----
 
 
@@ -141,9 +175,10 @@ RETURN ai.text.chat('Hello', null, 'openai', {token: $openaiToken, model: 'gpt-4
 .Example
 [source,cypher]
 ----
+CYPHER 25 // Keep this prefix if the database default is Cypher 5.
 CALL ai.text.chat.providers()
-YIELD name, requiredConfigType
-RETURN name, requiredConfigType
+YIELD name, requiredConfigType, optionalConfigType, defaultConfig
+RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
 ----
 
 
@@ -164,7 +199,17 @@ RETURN name, requiredConfigType
 .Example
 [source,cypher]
 ----
-RETURN ai.text.embed('The Matrix is a science fiction film.', 'openai', {token: $openaiToken, model: 'text-embedding-3-small'}) AS embedding
+CYPHER 25 // Keep this prefix if the database default is Cypher 5.
+WITH 'YOUR_OPENAI_API_KEY' AS openaiToken  // replace with a real token
+WITH {
+  token: openaiToken,
+  model: 'text-embedding-3-small'
+} AS conf
+RETURN ai.text.embed(
+  'Neo4j works well for connected data.',
+  'openai',
+  conf
+) AS embedding;
 ----
 
 
@@ -188,9 +233,19 @@ RETURN ai.text.embed('The Matrix is a science fiction film.', 'openai', {token: 
 .Example
 [source,cypher]
 ----
-CALL ai.text.embedBatch(['The Matrix', 'The Matrix Reloaded'], 'openai', {token: $openaiToken, model: 'text-embedding-3-small'})
+CYPHER 25 // Keep this prefix if the database default is Cypher 5.
+WITH
+  'YOUR_OPENAI_API_KEY' AS openaiToken,  // replace with a real token
+  ['graph database', 'vector search'] AS texts
+WITH
+  texts,
+  {
+    token: openaiToken,
+    model: 'text-embedding-3-small'
+  } AS conf
+CALL ai.text.embedBatch(texts, 'openai', conf)
 YIELD index, resource, vector
-RETURN index, resource, vector
+RETURN index, resource, vector;
 ----
 
 
@@ -211,15 +266,20 @@ RETURN index, resource, vector
 .Example
 [source,cypher]
 ----
+CYPHER 25 // Keep this prefix if the database default is Cypher 5.
 CALL ai.text.embed.providers()
-YIELD name, requiredConfigType
-RETURN name, requiredConfigType
+YIELD name, requiredConfigType, optionalConfigType, defaultConfig
+RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
 ----
 
 
 [[genai-vector-encode]]
 [role=label--function label--deprecated-Cypher-25]
 == genai.vector.encode()
+
+[WARNING]
+Deprecated in Cypher 25.
+Use xref:reference/functions-procedures.adoc#ai-text-embed[`ai.text.embed()`] instead.
 
 |===
 | *Syntax* 3+m| genai.vector.encode(resource, provider, configuration = {}) :: ANY
@@ -234,13 +294,27 @@ RETURN name, requiredConfigType
 .Example
 [source,cypher]
 ----
-RETURN genai.vector.encode('The Matrix is a science fiction film.', 'OpenAI', {token: $openaiToken, model: 'text-embedding-3-small'}) AS embedding
+// Legacy callable, deprecated in Cypher 25. Prefer ai.text.embed() for new examples.
+WITH 'YOUR_OPENAI_API_KEY' AS openaiToken  // replace with a real token
+WITH {
+  token: openaiToken,
+  model: 'text-embedding-ada-002'
+} AS conf
+RETURN genai.vector.encode(
+  'Neo4j works well for connected data.',
+  'OpenAI',
+  conf
+) AS embedding;
 ----
 
 
 [[genai-vector-encode-batch]]
 [role=label--procedure label--deprecated-Cypher-25]
 == genai.vector.encodeBatch()
+
+[WARNING]
+Deprecated in Cypher 25.
+Use xref:reference/functions-procedures.adoc#ai-text-embed-batch[`ai.text.embedBatch()`] instead.
 
 |===
 | *Syntax* 3+m| genai.vector.encodeBatch(resources, provider, configuration = {}) :: (index, resource, vector)
@@ -258,15 +332,29 @@ RETURN genai.vector.encode('The Matrix is a science fiction film.', 'OpenAI', {t
 .Example
 [source,cypher]
 ----
-CALL genai.vector.encodeBatch(['The Matrix', 'The Matrix Reloaded'], 'OpenAI', {token: $openaiToken, model: 'text-embedding-3-small'})
+// Legacy callable, deprecated in Cypher 25. Prefer ai.text.embedBatch() for new examples.
+WITH
+  'YOUR_OPENAI_API_KEY' AS openaiToken,  // replace with a real token
+  ['graph database', 'vector search'] AS texts
+WITH
+  texts,
+  {
+    token: openaiToken,
+    model: 'text-embedding-ada-002'
+  } AS conf
+CALL genai.vector.encodeBatch(texts, 'OpenAI', conf)
 YIELD index, resource, vector
-RETURN index, resource, vector
+RETURN index, resource, vector;
 ----
 
 
 [[genai-vector-list-encoding-providers]]
 [role=label--procedure label--deprecated-Cypher-25]
 == genai.vector.listEncodingProviders()
+
+[WARNING]
+Deprecated in Cypher 25.
+Use xref:reference/functions-procedures.adoc#ai-text-embed-providers[`ai.text.embed.providers()`] instead.
 
 |===
 | *Syntax* 3+m| genai.vector.listEncodingProviders() :: (name, requiredConfigType, optionalConfigType, defaultConfig)
@@ -281,7 +369,8 @@ RETURN index, resource, vector
 .Example
 [source,cypher]
 ----
+// Legacy callable, deprecated in Cypher 25. Prefer ai.text.embed.providers().
 CALL genai.vector.listEncodingProviders()
-YIELD name, requiredConfigType
-RETURN name, requiredConfigType
+YIELD name, requiredConfigType, optionalConfigType, defaultConfig
+RETURN name, requiredConfigType, optionalConfigType, defaultConfig;
 ----


### PR DESCRIPTION
## Summary
- add short guidance at the top of the reference page on functions vs procedures and Cypher 25 availability
- replace the added inline examples with links to the relevant guide pages
- add deprecation warnings for legacy `genai.vector.*` callables, pointing to the current `ai.text.*` replacements
- fix a stray quote in the provider reference table