### PR TITLE
Add docs for ai.file.embed

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -1,6 +1,7 @@
 * xref:index.adoc[]
 
 * xref:embeddings.adoc[]
+* xref:file-embeddings.adoc[]
 * xref:generate-text.adoc[]
 * xref:generate-structured-output.adoc[]
 * xref:count-tokens.adoc[]

--- a/modules/ROOT/pages/embeddings.adoc
+++ b/modules/ROOT/pages/embeddings.adoc
@@ -46,7 +46,8 @@ However, if the function call is misspelled or the query is otherwise malformed,
 
 [NOTE]
 This function sends one API request every time it is called, which may result in a lot of overhead in terms of both network traffic and latency.
-If you want to generate many embeddings at once, use xref:multiple-embeddings[].
+If you want to generate many embeddings at once, use xref:multiple-embeddings[] or xref:file-embeddings.adoc[].
+If you want to read text from a file and embed it, see xref:file-embeddings.adoc[].
 
 The examples below use the recommendations dataset described in xref:index.adoc#setup[Environment setup].
 Choose the tab that matches the setup you selected there.

--- a/modules/ROOT/pages/file-embeddings.adoc
+++ b/modules/ROOT/pages/file-embeddings.adoc
@@ -1,0 +1,202 @@
+:description: `ai.file.embedBatch` is used to embed text read from a file in batches as vectors using an AI provider.
+:table-caption!:
+
+[[file-embeddings]]
+= File embeddings
+
+The `ai.file.embedBatch` procedure reads text from a file and generates vector embeddings for its content.
+The file can be local to the Neo4j server or accessed via a URL (`http`, `https`, or `ftp`).
+
+[source, cypher]
+----
+CALL ai.file.embedBatch(
+  'https://example.com/large-document.txt', // <1>
+  'OpenAI', // <2>
+  { token: $apiKey, model: 'text-embedding-3-small' }, // <3>
+  1000 // <4>
+) YIELD index, resource, vector
+MERGE (n:Chunk {id: index})
+SET n.text = resource, n.embedding = vector
+----
+
+<1> The path or URL of the file to be read.
+<2> Identifier of the AI provider to use.
+<3> Provider-specific configuration.
+<4> The maximum token count limit for each chunk.
+
+`ai.file.embedBatch` supports both local and remote URLs.
+Local paths are resolved relative to the Neo4j installation folder.
+
+[NOTE]
+====
+Accessing files with `ai.file.embedBatch` requires link:{neo4j-docs-base-uri}/operations-manual/current/authentication-authorization/load-privileges/[load privileges].
+====
+
+== ai.file.embedBatch
+
+`ai.file.embedBatch` reads a file, optionally chunks it, and returns the embeddings. It attempts to use the given model, but if it is not supported will default to OpenAI's `ada` model.
+
+.Signature for `ai.file.embedBatch()`
+[role=label--procedure label--new-2026.05]
+[cols="1,1,1,3"]
+|===
+|    *Syntax*        3+| `ai.file.embedBatch(file, provider, configuration = {}, tokenCountLimit = null) :: (index, resource, vector)`
+|    *Description*   3+| Embed a given file in batches of resources as vectors using the named provider.
+
+.5+| *Inputs* | *Name* | *Type* | *Description*
+   | `file`
+   | `STRING`
+   | The path or URL of the file to be read.
+
+   | `provider`
+   | `STRING`
+   | Identifier of the AI provider to use. See xref:embeddings.adoc#providers[Embeddings -> Providers] for supported options.
+
+   | `configuration`
+   | `MAP`
+   | Provider-specific configuration. Use `CALL ai.text.embed.providers()` to find the configuration needed for each provider.
+
+   | `tokenCountLimit`
+   | `INTEGER`
+   | The maximum token count limit for each chunk. If `null` (default), chunking is not applied.
+
+.4+| *Returns* | *Name* | *Type* | *Description*
+   | `index`
+   | `INTEGER`
+   | The index of the corresponding chunk within the list of resources.
+
+   | `resource`
+   | `STRING`
+   | The original resource element (the chunk text).
+
+   | `vector`
+   | `VECTOR`
+   | The generated vector embedding for the resource.
+|===
+
+=== Chunking behavior
+
+* If `tokenCountLimit` is `null`, the entire file content is treated as a single resource and embedded.
+* If `tokenCountLimit` is provided, the file content is chunked into a list of resources, where each chunk's token count does not exceed the limit.
+* The procedure returns one row for each chunk, containing its index, the chunk text, and its embedding vector.
+
+== Embed text from files into Neo4j
+
+[role=label--not-on-aura]
+=== Import local files
+
+You can store files on the database server and then access them by using a `+file:///+` URL.
+By default, paths are resolved relative to the Neo4j import directory.
+
+.Embed text from a local file
+====
+
+.document.txt
+[source, text, filename="document.txt"]
+----
+Neo4j is a graph database management system.
+It is designed to store and process large-scale graphs.
+Graph databases are well-suited for highly connected data.
+----
+
+.Query
+[source, cypher]
+----
+CALL ai.file.embedBatch(
+  'file:///document.txt',
+  'OpenAI',
+  { token: $apiKey, model: 'text-embedding-3-small' }
+) YIELD index, resource, vector
+MERGE (c:Chunk {file: 'document.txt', index: index})
+SET c.text = resource, c.embedding = vector
+RETURN index, resource, vector
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="3*<m"]
+|===
+| index | resource                                                     | vector
+| 0     | 'Neo4j is a graph database management system.'               | [0.0052, -0.0393, ...]
+| 1     | 'It is designed to store and process large-scale graphs.'    | [0.0123, -0.0045, ...]
+| 2     | 'Graph databases are well-suited for highly connected data.' | [0.0089, 0.0212, ...]
+3+d|3 rows
+
+Added 3 nodes, Set 6 properties, Added 3 labels
+|===
+====
+
+==== Configuration settings for file URLs
+
+link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings#config_dbms.security.allow_csv_import_from_file_urls[dbms.security.allow_csv_import_from_file_urls]::
+This setting determines whether `+file:///+` URLs are allowed.
+
+link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings#config_server.directories.import[server.directories.import]::
+This setting sets the root directory relative to which `+file:///+` URLs are parsed.
+
+
+=== Import from a remote location
+
+You can embed text from a file hosted on a remote path.
+
+`ai.file.embedBatch` supports accessing files via HTTPS, HTTP, and FTP (with or without credentials).
+It also follows redirects, except those changing the protocol (for security reasons).
+
+.Embed text from a remote file via HTTPS
+====
+
+.https://example.com/document.txt
+[source, text, filename="document.txt"]
+----
+Neo4j GenAI plugin can read this file.
+You can generate embeddings from it.
+----
+
+.Query
+[source, cypher]
+----
+CALL ai.file.embedBatch(
+  'https://example.com/document.txt',
+  'OpenAI',
+  { token: $apiKey, model: 'text-embedding-3-small' }
+) YIELD index, resource, vector
+RETURN index, resource, vector
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="3*<m"]
+|===
+| index | resource                                                                       | vector
+| 0     | 'Neo4j GenAI plugin can read this file.\nYou can generate embeddings from it.' | [0.0052, -0.0393, ...]
+3+d|1 row
+|===
+====
+
+
+.Embed text from a remote file via FTP using credentials
+====
+
+.\ftp://<username>:<password>@<domain>/documents/file.txt
+[source, text, filename="file.txt"]
+----
+This is a file hosted on an FTP server.
+----
+
+.Query
+[source, cypher, role=test-skip]
+----
+CALL ai.file.embedBatch(
+  'ftp://<username>:<password>@<domain>/documents/file.txt',
+  'OpenAI',
+  { token: $apiKey, model: 'text-embedding-3-small' }
+) YIELD index, resource, vector
+RETURN index, resource, vector
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="2*<m"]
+|===
+| index | resource                                  | vector
+| 0     | 'This is a file hosted on an FTP server.' | [0.0052, -0.0393, ...]
+2+d|1 row
+|===
+====

--- a/modules/ROOT/pages/file-embeddings.adoc
+++ b/modules/ROOT/pages/file-embeddings.adoc
@@ -1,40 +1,40 @@
 :description: `ai.file.embedBatch` is used to embed text read from a file in batches as vectors using an AI provider.
 :table-caption!:
+:page-role: new--2025.05
 
-[[file-embeddings]]
-= File embeddings
 
-The `ai.file.embedBatch` procedure reads text from a file and generates vector embeddings for its content.
-The file can be local to the Neo4j server or accessed via a URL (`http`, `https`, or `ftp`).
+= Create and store file embeddings
+
+== Overview
+
+The `ai.file.embedBatch` procedure reads text from a local or remote file and generates vector embeddings for its content, optionally splitting it in chunks. It returns one row for each chunk, containing its index, the chunk content, and its embedding vector.
 
 [source, cypher]
 ----
 CALL ai.file.embedBatch(
   'https://example.com/large-document.txt', // <1>
   'OpenAI', // <2>
-  { token: $apiKey, model: 'text-embedding-3-small' }, // <3>
+  { token: $openaiToken, model: 'text-embedding-3-small' }, // <3>
   1000 // <4>
 ) YIELD index, resource, vector
 MERGE (n:Chunk {id: index})
 SET n.text = resource, n.embedding = vector
 ----
 
-<1> The path or URL of the file to be read.
-<2> Identifier of the AI provider to use.
-<3> Provider-specific configuration.
-<4> The maximum token count limit for each chunk.
-
-`ai.file.embedBatch` supports both local and remote URLs.
+<1> The path or URL of the source file.
+Both local and remote URLs (`http`, `https`, or `ftp`) are supported.
 Local paths are resolved relative to the Neo4j installation folder.
+<2> Identifier of the AI provider to use.
+If the given model is not supported, OpenAI's `ada` model is used.
+<3> Provider-specific configuration.
+<4> The maximum token count for each chunk.
+
+
 
 [NOTE]
 ====
 Accessing files with `ai.file.embedBatch` requires link:{neo4j-docs-base-uri}/operations-manual/current/authentication-authorization/load-privileges/[load privileges].
 ====
-
-== ai.file.embedBatch
-
-`ai.file.embedBatch` reads a file, optionally chunks it, and returns the embeddings. It attempts to use the given model, but if it is not supported will default to OpenAI's `ada` model.
 
 .Signature for `ai.file.embedBatch()`
 [role=label--procedure label--new-2026.05]
@@ -46,7 +46,7 @@ Accessing files with `ai.file.embedBatch` requires link:{neo4j-docs-base-uri}/op
 .5+| *Inputs* | *Name* | *Type* | *Description*
    | `file`
    | `STRING`
-   | The path or URL of the file to be read.
+   | The path or URL of the file to read.
 
    | `provider`
    | `STRING`
@@ -74,18 +74,23 @@ Accessing files with `ai.file.embedBatch` requires link:{neo4j-docs-base-uri}/op
    | The generated vector embedding for the resource.
 |===
 
-=== Chunking behavior
 
-* If `tokenCountLimit` is `null`, the entire file content is treated as a single resource and embedded.
-* If `tokenCountLimit` is provided, the file content is chunked into a list of resources, where each chunk's token count does not exceed the limit.
-* The procedure returns one row for each chunk, containing its index, the chunk text, and its embedding vector.
+.Chunking behavior
+[NOTE]
+====
+* If `tokenCountLimit` is `null`, the entire file content is embedded as a single resource.
+* If `tokenCountLimit` is provided, the file content is chunked into a list of resources, each within the token count limit.
+====
 
-== Embed text from files into Neo4j
 
+[#examples]
+== Examples
+
+[#example-local]
 [role=label--not-on-aura]
 === Import local files
 
-You can store files on the database server and then access them by using a `+file:///+` URL.
+You can store files on the database server and access them by using the `+file:///+` schema.
 By default, paths are resolved relative to the Neo4j import directory.
 
 .Embed text from a local file
@@ -105,7 +110,7 @@ Graph databases are well-suited for highly connected data.
 CALL ai.file.embedBatch(
   'file:///document.txt',
   'OpenAI',
-  { token: $apiKey, model: 'text-embedding-3-small' }
+  { token: $openaiToken, model: 'text-embedding-3-small' }
 ) YIELD index, resource, vector
 MERGE (c:Chunk {file: 'document.txt', index: index})
 SET c.text = resource, c.embedding = vector
@@ -125,20 +130,22 @@ Added 3 nodes, Set 6 properties, Added 3 labels
 |===
 ====
 
-==== Configuration settings for file URLs
-
+.Configuration settings for file URLs
+[NOTE]
+====
 link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings#config_dbms.security.allow_csv_import_from_file_urls[dbms.security.allow_csv_import_from_file_urls]::
-This setting determines whether `+file:///+` URLs are allowed.
+Whether `+file:///+` URLs are allowed.
 
 link:{neo4j-docs-base-uri}/operations-manual/current/configuration/configuration-settings#config_server.directories.import[server.directories.import]::
-This setting sets the root directory relative to which `+file:///+` URLs are parsed.
+The path relative to which `+file:///+` URLs are parsed.
+====
 
 
+[#example-remote]
 === Import from a remote location
 
-You can embed text from a file hosted on a remote path.
-
-`ai.file.embedBatch` supports accessing files via HTTPS, HTTP, and FTP (with or without credentials).
+`ai.file.embedBatch` can embed text from a file hosted on a remote path.
+It supports accessing files via HTTPS, HTTP, and FTP (with or without credentials).
 It also follows redirects, except those changing the protocol (for security reasons).
 
 .Embed text from a remote file via HTTPS
@@ -152,12 +159,12 @@ You can generate embeddings from it.
 ----
 
 .Query
-[source, cypher]
+[source, cypher, test-skip]
 ----
 CALL ai.file.embedBatch(
   'https://example.com/document.txt',
   'OpenAI',
-  { token: $apiKey, model: 'text-embedding-3-small' }
+  { token: $openaiToken, model: 'text-embedding-3-small' }
 ) YIELD index, resource, vector
 RETURN index, resource, vector
 ----
@@ -187,16 +194,16 @@ This is a file hosted on an FTP server.
 CALL ai.file.embedBatch(
   'ftp://<username>:<password>@<domain>/documents/file.txt',
   'OpenAI',
-  { token: $apiKey, model: 'text-embedding-3-small' }
+  { token: $openaiToken, model: 'text-embedding-3-small' }
 ) YIELD index, resource, vector
 RETURN index, resource, vector
 ----
 
 .Result
-[role="queryresult",options="header,footer",cols="2*<m"]
+[role="queryresult",options="header,footer",cols="3*<m"]
 |===
 | index | resource                                  | vector
 | 0     | 'This is a file hosted on an FTP server.' | [0.0052, -0.0393, ...]
-2+d|1 row
+3+d|1 row
 |===
 ====

--- a/modules/ROOT/pages/reference/changelog.adoc
+++ b/modules/ROOT/pages/reference/changelog.adoc
@@ -16,6 +16,29 @@ Cypher 25 was introduced in Neo4j 2025.06 and can only be used on Neo4j 2025.06+
 For more information, see link:{neo4j-docs-base-uri}/cypher-manual/25/queries/select-version[Cypher Manual -> Select Cypher version].
 
 
+
+[[neo4j-2026.05]]
+== Neo4j 2026.05
+
+=== New in Cypher 25
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+[source, cypher]
+----
+CALL ai.file.embedBatch(file, provider, configuration, tokenCountLimit)
+----
+| New procedure xref:reference/functions-procedures.adoc#ai-file-embed-batch[`ai.file.embedBatch()`] to read and embed text from a file (local or URL) in batches.
+
+See xref:file-embeddings.adoc[].
+
+|===
+
+
 [[neo4j-2026.04]]
 == Neo4j 2026.04
 

--- a/modules/ROOT/pages/reference/functions-procedures.adoc
+++ b/modules/ROOT/pages/reference/functions-procedures.adoc
@@ -8,6 +8,27 @@ For more information, see link:https://neo4j.com/docs/cypher-manual/current/func
 Most GenAI features are available only in Cypher 25.
 If your database's default language is Cypher 5, prepend the query with `CYPHER 25` to override the default for that query (see link:https://neo4j.com/docs/cypher-manual/current/queries/select-version/[Cypher -> Select Cypher version]).
 
+
+[[ai-file-embed-batch]]
+[role=label--procedure label--new-2026.05 label--Cypher-25]
+== ai.file.embedBatch()
+|===
+|    *Syntax*        3+| `ai.file.embedBatch(file, provider, configuration = {}, tokenCountLimit = null) :: (index, resource, vector)`
+|    *Description*   3+| Embed a given file in batches of resources as vectors using the named provider.
+.5+| *Input arguments* | *Name*            | *Type*    | *Description*
+|                        `file`             | `STRING`  | The path or URL of the file to be read.
+|                        `provider`         | `STRING`  | The identifier of the provider: 'Azure-OpenAI', 'Bedrock-Titan', 'OpenAI', 'VertexAI'.
+|                        `configuration`    | `MAP`     | Provider specific configuration.
+|                        `tokenCountLimit`  | `INTEGER` | The maximum token count limit for each chunk, if `null`, chunking will not be applied. Default is `null`.
+.4+| *Returns*          | *Name*            | *Type*    | *Description*
+|                        `index`            | `INTEGER` | The index of the corresponding element in the input list.
+|                        `resource`         | `STRING`  | The name of the input resource.
+|                        `vector`           | `VECTOR`  | The generated vector embedding for the resource.
+|===
+
+For usage examples, see xref:file-embeddings.adoc[].
+
+
 [[ai-text-aggregate-completion]]
 [role=label--function label--new-2026.03 label--Cypher-25]
 == ai.text.aggregateCompletion()


### PR DESCRIPTION
New procedure which behaves like LOAD CSV in how it reads files (except for all files, not just csv) and then optionally chunks the data before sending it to be embedded.